### PR TITLE
fix docker-compose.prod.yml & get plans order

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,7 +37,8 @@ services:
       - "traefik.http.routers.backend.tls=true"
       - "traefik.http.routers.backend.tls.certresolver=cloudflare"
       - "traefik.http.routers.backend.service=backend"
-      - "traefik.http.middlewares.stripPrefix.stripPrefix.prefixes=/api"
+      - "traefik.http.routers.backend.middlewares=api-middleware@docker"
+      - "traefik.http.middlewares.api-middleware.stripprefix.prefixes=/api"
       - "traefik.http.services.backend.loadbalancer.server.port=80"
       - "traefik.docker.network=proxy"
   postgres-db:

--- a/service/app/services/plan_service.py
+++ b/service/app/services/plan_service.py
@@ -23,13 +23,18 @@ def get_plans(user_id: UUID, session: Session) -> Sequence[PlanRead]:
             and_(Plan.group_version_id == subquery.c.group_version_id, Plan.created_at == subquery.c.max_created_at),
         )
         .where(Plan.user_id == user_id)
+        .order_by(Plan.bookmark.desc(), Plan.name)
     )
     plans = session.exec(statement).all()
     return [PlanRead.model_validate(plan) for plan in plans]
 
 
 def get_plan_by_public_slug(public_slug: str, session: Session) -> PlanRead:
-    statement = select(Plan).where(Plan.public_slug == public_slug).order_by(Plan.created_at.desc())
+    statement = (
+        select(Plan)
+        .where(Plan.public_slug == public_slug)
+        .order_by(Plan.created_at.desc())
+    )
     plan = session.exec(statement).first()
     if not plan:
         error_msg = "Plan not found"
@@ -40,7 +45,9 @@ def get_plan_by_public_slug(public_slug: str, session: Session) -> PlanRead:
 def get_plan_history(plan_id: UUID, session: Session) -> Sequence[PlanRead]:
     current_plan = session.get(Plan, plan_id)
     statement = (
-        select(Plan).where(Plan.group_version_id == current_plan.group_version_id).order_by(Plan.created_at.desc())
+        select(Plan)
+        .where(Plan.group_version_id == current_plan.group_version_id)
+        .order_by(Plan.created_at.desc())
     )
     plans = session.exec(statement).all()
     return [PlanRead.model_validate(plan) for plan in plans]


### PR DESCRIPTION
fixed traefik rules in docker-compose.prod.yml -> (following example in web systemtest docker-compose)
fixed ordering of plans to have bookmarked on top